### PR TITLE
Improves on `setup.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.py[cod]
 *.egg-info
 
+# Build products
+build/
+dist/
+
 # Test coverage files
 .coverage
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,25 @@ For more build options, simply run the following command.
 Other build targets can be specified using the ``-b`` or ``--builder`` option.
 Beyond the standard options that Sphinx provides, we add the `pdf` option.
 
+Cleaning
+========
+
+To clean up the directory after building, one can use the ``clean`` option.
+This will eliminate all intermediates build products. The syntax is shown
+below.
+
+::
+
+    python setup.py clean
+
+If this is not sufficient, and one wishes to eliminate the final products this
+can be done with the flag ``-a`` or ``--all``. This adjustment to the syntax is
+shown below.
+
+::
+
+    python setup.py clean --all
+
 Usage
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,28 @@ Test the program using the following command:
 
     python setup.py tests
 
+Documentation
+=============
+
+Documentation can be built from source on any platform easily. Just run the
+following command.
+
+::
+
+    python setup.py build_sphinx
+
+This will generate HTML documentation, which can be open using this file
+``build/sphinx/html/index.html`` in the current directory.
+
+For more build options, simply run the following command.
+
+::
+
+    python setup.py build_sphinx --help
+
+Other build targets can be specified using the ``-b`` or ``--builder`` option.
+Beyond the standard options that Sphinx provides, we add the `pdf` option.
+
 Usage
 =====
 

--- a/mouse/__init__.py
+++ b/mouse/__init__.py
@@ -78,9 +78,47 @@ the ``mouse_record`` file is located. Then enter the following command:
 Documentation
 ===============================================================================
 
-Documentation can be built from source on any platform easily. To do this enter
-the ``docs/`` directory. A number of different formats can be used. However,
-the design target is HTML. To build the HTML docs, enter the following command.
+Documentation can be built from source on any platform easily. Just run the
+following command.
+
+.. code-block:: sh
+
+    python setup.py build_sphinx
+
+This will generate HTML documentation, which can be open using this file
+``build/sphinx/html/index.html`` in the current directory.
+
+For more build options, simply run the following command.
+
+.. code-block:: sh
+
+    python setup.py build_sphinx --help
+
+Other build targets can be specified using the ``-b`` or ``--builder`` option.
+Beyond the standard options that Sphinx provides, we add the `pdf` option.
+
+To clean up the documentation built and all other build products, one can use
+the ``clean`` option. This will eliminate all intermediates used to build the
+documentation along with any other products ``clean`` would normally take care
+of. The syntax is shown below.
+
+.. code-block:: sh
+
+    python setup.py clean
+
+If this is not sufficient, and one wishes to eliminate the final documentation
+product this can be done with the flag ``-a`` or ``--all``. This adjustment to
+the syntax is shown below.
+
+.. code-block:: sh
+
+    python setup.py clean --all
+
+Alternatively, if one does not wish to use ``setup.py``, one can use a Makefile
+or ``make.bat`` on Windows in the ``docs/`` directory to generate
+documentation. To do this enter the ``docs/`` directory. A number of different
+formats can be used. However, the design target is HTML. To build the HTML
+docs, enter the following command.
 
 .. code-block:: sh
 

--- a/mouse/__init__.py
+++ b/mouse/__init__.py
@@ -97,23 +97,6 @@ For more build options, simply run the following command.
 Other build targets can be specified using the ``-b`` or ``--builder`` option.
 Beyond the standard options that Sphinx provides, we add the `pdf` option.
 
-To clean up the documentation built and all other build products, one can use
-the ``clean`` option. This will eliminate all intermediates used to build the
-documentation along with any other products ``clean`` would normally take care
-of. The syntax is shown below.
-
-.. code-block:: sh
-
-    python setup.py clean
-
-If this is not sufficient, and one wishes to eliminate the final documentation
-product this can be done with the flag ``-a`` or ``--all``. This adjustment to
-the syntax is shown below.
-
-.. code-block:: sh
-
-    python setup.py clean --all
-
 Alternatively, if one does not wish to use ``setup.py``, one can use a Makefile
 or ``make.bat`` on Windows in the ``docs/`` directory to generate
 documentation. To do this enter the ``docs/`` directory. A number of different
@@ -138,6 +121,26 @@ following command.
 .. code-block:: sh
 
     make clean
+
+===============================================================================
+Cleaning
+===============================================================================
+
+To clean up all build products, one can use the ``clean`` option. This will
+eliminate all intermediates used to build. This has been amended to include
+picking up documentation build intermediates. The syntax is shown below.
+
+.. code-block:: sh
+
+    python setup.py clean
+
+If this is not sufficient, and one wishes to eliminate the final products, as
+well. This can be done with the flag ``-a`` or ``--all``. This adjustment to
+the syntax is shown below.
+
+.. code-block:: sh
+
+    python setup.py clean --all
 
 ===============================================================================
 Usage

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ __author__ = "Bailey Hwa <hwab@janelia.hhmi.org>"
 __date__ = "$July 30, 2015 20:20:18 EDT$"
 
 from glob import glob
+
 from setuptools import setup, find_packages
 
 import versioneer

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,79 @@ __author__ = "Bailey Hwa <hwab@janelia.hhmi.org>"
 __date__ = "$July 30, 2015 20:20:18 EDT$"
 
 from glob import glob
+import os
+import shutil
+import sys
 
 from setuptools import setup, find_packages
 
 import versioneer
 
+
+build_requires = []
+install_requires = []
+tests_require = ["nose"]
+sphinx_build_pdf = False
+if len(sys.argv) == 1:
+    pass
+elif sys.argv[1] == "build_sphinx":
+    import sphinx.apidoc
+
+    sphinx.apidoc.main([
+        sphinx.apidoc.__file__,
+        "-f", "-T", "-e", "-M",
+        "-o", "docs",
+        ".", "setup.py", "tests", "versioneer.py"
+    ])
+
+    build_prefix_arg_index = None
+    for each_build_arg in ["-b", "--builder"]:
+        try:
+            build_arg_index = sys.argv.index(each_build_arg)
+        except ValueError:
+            continue
+
+        if sys.argv[build_arg_index + 1] == "pdf":
+            sphinx_build_pdf = True
+            sys.argv[build_arg_index + 1] = "latex"
+elif sys.argv[1] == "clean":
+    saved_rst_files = ["docs/index.rst", "docs/readme.rst", "docs/todo.rst"]
+
+    tmp_rst_files = glob("docs/*.rst")
+
+    print("removing 'docs/*.rst'")
+    for each_saved_rst_file in saved_rst_files:
+        print("skipping '" + each_saved_rst_file + "'")
+        tmp_rst_files.remove(each_saved_rst_file)
+
+    for each_tmp_rst_file in tmp_rst_files:
+        os.remove(each_tmp_rst_file)
+
+    if os.path.exists("build/sphinx/doctrees"):
+        print("removing 'build/sphinx/doctrees'")
+        shutil.rmtree("build/sphinx/doctrees")
+    else:
+        print("'build/sphinx/doctrees' does not exist -- can't clean it")
+
+    if os.path.exists(".eggs"):
+        print("removing '.eggs'")
+        shutil.rmtree(".eggs")
+    else:
+        print("'.eggs' does not exist -- can't clean it")
+
+    if (len(sys.argv) > 2) and (sys.argv[2] in ["-a", "--all"]):
+        if os.path.exists("build/sphinx"):
+            print("removing 'build/sphinx'")
+            shutil.rmtree("build/sphinx")
+        else:
+            print("'build/sphinx' does not exist -- can't clean it")
+elif sys.argv[1] == "develop":
+    if (len(sys.argv) > 2) and (sys.argv[2] in ["-u", "--uninstall"]):
+        if os.path.exists("mouse_recorder.egg-info"):
+            print("removing 'mouse_recorder.egg-info'")
+            shutil.rmtree("mouse_recorder.egg-info")
+        else:
+            print("'mouse_recorder.egg-info' does not exist -- can't clean it")
 
 setup(
     name="mouse_recorder",
@@ -27,3 +95,10 @@ setup(
     test_suite="nose.collector",
     zip_safe=True
 )
+
+if sphinx_build_pdf:
+    make_cmd = os.environ.get("MAKE", "make")
+    cwd = os.getcwd()
+    os.chdir("build/sphinx/latex")
+    os.execlpe(make_cmd, "all", os.environ)
+    os.chdir(cwd)


### PR DESCRIPTION
- Provides ability to build documentation with `setup.py` directly.
- Improves on `setup.py`'s ability to clean.
- Adds documentation to show how to use these features.
- Expands the list of things ignored by `git`.
